### PR TITLE
Base class for PNC node

### DIFF
--- a/small_proj_ws/src/hkj_msgs/msg/perception/RoadConditionVector.msg
+++ b/small_proj_ws/src/hkj_msgs/msg/perception/RoadConditionVector.msg
@@ -2,3 +2,9 @@ Header Header
 
 hkj_msgs/RoadCondition[] road_condition_vt
 hkj_msgs/ObstacleRect[] obstacle_rectangles
+float64 pos_x
+float64 pos_y
+float64 vel_x
+float64 vel_y
+float64 yaw_angle
+float64 yaw_rate

--- a/small_proj_ws/src/hkj_msgs/msg/pnc/VehicleActuator.msg
+++ b/small_proj_ws/src/hkj_msgs/msg/pnc/VehicleActuator.msg
@@ -1,4 +1,4 @@
 Header header
 
-float64 applied_force
-float64 steer_angle
+float64[] applied_force
+float64[] steer_angle

--- a/small_proj_ws/src/mpc_traj_follower/include/mpc_traj_follower/perception.h
+++ b/small_proj_ws/src/mpc_traj_follower/include/mpc_traj_follower/perception.h
@@ -37,7 +37,7 @@ class Perception {
      * prepare perception msg based on state feedback from plant_model_node
      * return true if perception msg is correctly prepared
      * */
-    hkj_msgs::RoadConditionVector preparePerceptionMsg(double x, double y);
+    hkj_msgs::RoadConditionVector preparePerceptionMsg(const hkj_msgs::VehicleState::ConstPtr& msg);
     void publishPerceptionMsg();
 
   private:

--- a/small_proj_ws/src/mpc_traj_follower/include/mpc_traj_follower/pnc.h
+++ b/small_proj_ws/src/mpc_traj_follower/include/mpc_traj_follower/pnc.h
@@ -15,49 +15,20 @@
 
 namespace mpc_traj_follower {
 
-struct Obstacle {
-  public:
-    float pos_x[4] = {0.0, 0.0, 0.0, 0.0};
-    float pos_y[4] = {0.0, 0.0, 0.0, 0.0};
-};
-
 class PNC {
   public:
     PNC(ros::NodeHandle& nh);
     ~PNC();
 
+    void perceptionCallback(const hkj_msgs::RoadConditionVector::ConstPtr& msg);
+    virtual hkj_msgs::VehicleActuator prepareVehicleInput(const hkj_msgs::RoadConditionVector::ConstPtr& msg);  // Override this in derived classs
+
   private:
     /* ROS */
     ros::NodeHandle nh_;
-    ros::Subscriber sub_road_cond_;                   // receive from plant_model_node
-    ros::Subscriber sub_cur_state_;                   // receive from plant_model_node
-    ros::Publisher  pub_actuation_;                   // publish to vehicle_plant_node
-
-    /* Variable */
-    // perception
-    bool new_perception_;                             // if a new perception signal received
-    std::vector<float> left_bound_wps_x_;               // left bound waypoint x position vector
-    std::vector<float> left_bound_wps_y_;               // left bound waypoint y position vector
-    std::vector<float> right_bound_wps_x_;              // right bound waypoint x position vector
-    std::vector<float> right_bound_wps_y_;              // right bound waypoint y position vector
-    std::vector<float> mid_line_wps_x_;                 // middle line waypoint x position vector
-    std::vector<float> mid_line_wps_y_;                 // middle line waypoint y position vector
-    std::vector<Obstacle> obs_vec_;                   // obstacle sets vector
-    // vehicle state
-    bool new_veh_state_;                              // if a new vehicle state is received
-    std::vector<float> received_veh_state_;           // vehicle state received from plant_model_node
-    std::vector<std::vector<float>> actuator_traj_;   // trajectory of actuator
-    std::vector<float> next_actuator_;                // actuator value to be sent to plant_model_node
-
-    void perceptionCallback(const hkj_msgs::RoadConditionVector::ConstPtr& msg);
-    void vehicleStatesCallback(const hkj_msgs::VehicleState::ConstPtr& msg);
-    void clearPerception();
-    void clearVehicleState();
-    bool checkNewPerception() const { return new_perception_; }
-    bool checkNewVehState() const  {return new_veh_state_; }
-    bool preparedForProcessing() const;
-    void processing();
-    void publishActuation();
+    ros::Subscriber sub_;                   // receive from perception node
+    ros::Publisher  pub_;                   // publish to vehicle_plant_node
+    
 };
 
 } /* end of namespace mpc_traj_follower */

--- a/small_proj_ws/src/mpc_traj_follower/include/mpc_traj_follower/vehicle_plant_model.h
+++ b/small_proj_ws/src/mpc_traj_follower/include/mpc_traj_follower/vehicle_plant_model.h
@@ -22,6 +22,7 @@ class VehiclePlantModel {
 
     // Publish vehicle state - It is made public only for testing purpose
     void publishVehicleMsg(float pos_x, float pos_y, float vel_x, float vel_y, float yaw_angle, float yaw_rate);
+    void setState(float pos_x, float pos_y, float vel_x, float vel_y, float yaw_angle, float yaw_rate);
   
   private:
     /* ROS */
@@ -48,9 +49,6 @@ class VehiclePlantModel {
 
     /* Params */
     void actuationCallback(const hkj_msgs::VehicleActuator::ConstPtr& msg);
-
-    // perception callback, for testing only...
-    void perceptionCallback(const hkj_msgs::RoadConditionVector::ConstPtr& msg);
 
     // Vehicle plant model
     // TODO: expand it with a generic template when dealing with multiple vehicle models

--- a/small_proj_ws/src/mpc_traj_follower/launch/pipeline.launch
+++ b/small_proj_ws/src/mpc_traj_follower/launch/pipeline.launch
@@ -3,7 +3,8 @@
     <param name="distance_can_see" type="double" value="50.0"/>
     <param name="integration_dt" type="double" value="1.0"/>
     
-    <node name="perception_node"     pkg="mpc_traj_follower"   type="perception"           output="screen" launch-prefix="gdb -ex run --args"/>
-    <node name="vehicle_plant_node"  pkg="mpc_traj_follower"   type="vehicle_plant_model"  output="screen" launch-prefix="gdb -ex run --args"/>
-    <node name="plot"                pkg="mpc_traj_follower"   type="plot_vehicle.py"            output="screen"/>
+    <node name="plot"                pkg="mpc_traj_follower"   type="plot_vehicle.py"      output="screen"/>
+    <node name="perception_node"     pkg="mpc_traj_follower"   type="perception"           output="screen"/>
+    <node name="vehicle_plant_node"  pkg="mpc_traj_follower"   type="vehicle_plant_model"  output="screen"/>
+    <node name="plan_control_node"   pkg="mpc_traj_follower"   type="pnc"                  output="screen"/>
 </launch>

--- a/small_proj_ws/src/mpc_traj_follower/script/plot_vehicle.py
+++ b/small_proj_ws/src/mpc_traj_follower/script/plot_vehicle.py
@@ -47,6 +47,8 @@ class Visualiser:
         ax.axis([l_x,u_x,l_y,u_y])
         ax.plot(left_x, left_y, "b-")
         ax.plot(right_x, right_y, "b-")
+        fig.canvas.draw()
+        plt.pause(1e-3)
         return fig, ax
     
     def callback(self, data):

--- a/small_proj_ws/src/mpc_traj_follower/src/pnc.cpp
+++ b/small_proj_ws/src/mpc_traj_follower/src/pnc.cpp
@@ -4,98 +4,36 @@ namespace mpc_traj_follower {
 
 PNC::PNC(ros::NodeHandle& nh) : nh_(nh)
 {   
-    /* Variables */
-    new_perception_ = false;
-    new_veh_state_  = false;
-
     /* ROS */
-    sub_road_cond_  = nh_.subscribe("/perception", 10, &PNC::perceptionCallback, this);
-    sub_cur_state_  = nh_.subscribe("/vehicle_states", 10, &PNC::vehicleStatesCallback, this);
-    pub_actuation_  = nh_.advertise<hkj_msgs::VehicleActuator>("/vehicle_actuator", 10);
+    sub_  = nh_.subscribe("/perception", 10, &PNC::perceptionCallback, this);
+    pub_  = nh_.advertise<hkj_msgs::VehicleActuator>("/vehicle_actuator", 10);
 
-    ROS_INFO("Initialized pnc_node!");
+    while (pub_.getNumSubscribers() < 1)
+        continue;
+
+    ROS_INFO("PNC - Initialized pnc_node!");
 }
 
 PNC::~PNC() {}
 
 void PNC::perceptionCallback(const hkj_msgs::RoadConditionVector::ConstPtr& msg)
 {   
-    // clear stored perception data
-    clearPerception();
-    // set receiving new perception flag true
-    new_perception_ = true;
+    hkj_msgs::VehicleActuator act_msg = this->prepareVehicleInput(msg);
+    pub_.publish(act_msg);
+    ROS_INFO("PNC - Actuation input published.");
+}
 
-    for (auto& elem : msg->road_condition_vt)
+hkj_msgs::VehicleActuator PNC::prepareVehicleInput(const hkj_msgs::RoadConditionVector::ConstPtr& msg)
+{
+    hkj_msgs::VehicleActuator act_msg;
+    
+    for (int i=0; i<11; ++i)
     {
-        left_bound_wps_x_.push_back(elem.left_wp[0]);
-        right_bound_wps_x_.push_back(elem.right_wp[0]);
-        mid_line_wps_x_.push_back(elem.mid_wp[0]);
-
-        left_bound_wps_y_.push_back(elem.left_wp[1]);
-        right_bound_wps_y_.push_back(elem.right_wp[1]);
-        mid_line_wps_y_.push_back(elem.mid_wp[1]);
+        act_msg.applied_force.push_back(0.0);
+        act_msg.steer_angle.push_back(0.0);
     }
 
-    for (auto& elem : msg->obstacle_rectangles)
-    {   
-        Obstacle obs;
-        for (int i = 0; i < 4; i++) 
-        {
-            obs.pos_x[i] = elem.obstacle_rectangle_pos_x[i];
-            obs.pos_y[i] = elem.obstacle_rectangle_pos_y[i];
-        }
-        obs_vec_.push_back(obs);
-    }
-}
-
-void PNC::vehicleStatesCallback(const hkj_msgs::VehicleState::ConstPtr& msg)
-{   
-    // clear stored vehicle state data
-    clearVehicleState();
-    // set receiving new veh state flag true
-    new_veh_state_ = true;
-
-    received_veh_state_.push_back(msg->pos_x);
-    received_veh_state_.push_back(msg->pos_y);
-    received_veh_state_.push_back(msg->vel_x);
-    received_veh_state_.push_back(msg->vel_y);
-    received_veh_state_.push_back(msg->yaw_angle);
-    received_veh_state_.push_back(msg->yaw_rate);
-}
-
-// CORE FUNCTION OF TRAJ OPTIMIZATION & MPC CONTROL
-void PNC::processing()
-{
-    /** [Psudo code]
-     * 
-     *  Actuation(t + 1) = F( State(t), Perception(t + 1) );
-     *  next_actuator = std::vector<float>{};
-     *  for ( auto& elem : Actuation(t + 1) )
-     *      next_actuator.push_back(elem);
-     * 
-     * */
-
-    hkj_msgs::VehicleActuator next_veh_actuator;
-    next_veh_actuator.applied_force = actuator_traj_.back()[0];
-    next_veh_actuator.steer_angle   = actuator_traj_.back()[1];
-}
-
-// clear previous stored perception data
-void PNC::clearPerception()
-{
-    left_bound_wps_x_.clear();
-    left_bound_wps_y_.clear();
-    right_bound_wps_x_.clear();
-    right_bound_wps_y_.clear();
-    mid_line_wps_x_.clear();
-    mid_line_wps_y_.clear();
-    obs_vec_.clear();
-}
-
-// clear previous stored vehicle state data
-void PNC::clearVehicleState()
-{
-    received_veh_state_.clear();
+    return act_msg;
 }
 
 } /* end of namespace mpc_traj_follower */


### PR DESCRIPTION
1. Add base class for PNC node. New pnc node should derive from PNC class and override the prepareVehicleInput method.
2. Add dummy pnc node (object of base class) in launch file